### PR TITLE
Export CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,22 @@ INSTALL(FILES "${PIO_BINARY_DIR}/libpio.settings"
   DESTINATION lib
   COMPONENT libraries)
 
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/PIOConfigVersion.cmake"
+  VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+  COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/PIOConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/PIOConfig.cmake"
+  INSTALL_DESTINATION lib/cmake/PIO)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/PIOConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/PIOConfigVersion.cmake"
+  DESTINATION lib/cmake/PIO)
+
 #####
 # Create pio_meta.h include file.
 #####

--- a/cmake/PIOConfig.cmake.in
+++ b/cmake/PIOConfig.cmake.in
@@ -1,0 +1,52 @@
+@PACKAGE_INIT@
+
+if(NOT PIO_FIND_QUIETLY)
+  message(STATUS "Found PIO: ${PACKAGE_PREFIX_DIR}")
+endif()
+
+set(PIO_ENABLE_TIMING @PIO_ENABLE_TIMING@)
+set(PIO_ENABLE_FORTRAN @PIO_ENABLE_FORTRAN@)
+
+# The following components are supported by PIO (order is important)
+set(_supported_components GPTL C Fortran)
+
+# Check validity of requested components
+foreach(_comp ${PIO_FIND_COMPONENTS})
+  if(NOT _comp IN_LIST _supported_components)
+    set(PIO_FOUND False)
+    set(PIO_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+  endif()
+endforeach()
+
+# Some components are only available if they were built
+if (GPTL IN_LIST PIO_FIND_COMPONENTS AND NOT PIO_ENABLE_TIMING)
+  set(PIO_FOUND False)
+  set(PIO_NOT_FOUND_MESSAGE "The following component is unavailable: GPTL")
+endif()
+if (Fortran IN_LIST PIO_FIND_COMPONENTS AND NOT PIO_ENABLE_FORTRAN)
+  set(PIO_FOUND False)
+  set(PIO_NOT_FOUND_MESSAGE "The following component is unavailable: Fortran")
+endif()
+
+# Build a list of all the required components, taking into account their dependencies
+set(_required_components ${PIO_FIND_COMPONENTS})
+if(C IN_LIST _required_components)
+  if(PIO_ENABLE_TIMING)
+    list(APPEND _required_components GPTL)
+  endif()
+endif()
+if(Fortran IN_LIST _required_components)
+  list(APPEND _required_components C)
+  if(PIO_ENABLE_TIMING)
+    list(APPEND _required_components GPTL)
+  endif()
+endif()
+list(REMOVE_DUPLICATES _required_components)
+
+# Include required targets. We do this by looping over the _supported_components
+# list because the order in which targets are loaded matters.
+foreach(_comp ${_supported_components})
+  if(_comp IN_LIST _required_components)
+    include("${CMAKE_CURRENT_LIST_DIR}/PIO${_comp}Targets.cmake")
+  endif()
+endforeach()

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -49,11 +49,11 @@ include_directories(
 
 # Include the clib source directory
 target_include_directories (pioc
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 # Include the ncint source directory
 target_include_directories (pioc
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../ncint)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../ncint>)
 
 # System and compiler CPP directives
 target_compile_definitions (pioc
@@ -76,11 +76,21 @@ endif()
 #  DEFINE THE INSTALL
 #==============================================================================
 
+set_target_properties(pioc PROPERTIES EXPORT_NAME PIO_C)
+
 # Library
-install (TARGETS pioc DESTINATION lib)
+install (TARGETS pioc
+  EXPORT PIOCTargets
+  DESTINATION lib
+  INCLUDES DESTINATION include)
 
 # Include/Header Files
 install (FILES pio.h uthash.h DESTINATION include)
+
+install(EXPORT PIOCTargets
+  FILE PIOCTargets.cmake
+  NAMESPACE PIO::
+  DESTINATION lib/cmake/PIO)
 
 #==============================================================================
 #  DEFINE THE DEPENDENCIES
@@ -141,7 +151,7 @@ endif ()
 
 #===== Add EXTRAs =====
 target_include_directories (pioc
-  PUBLIC ${PIO_C_EXTRA_INCLUDE_DIRS})
+  PUBLIC $<BUILD_INTERFACE:${PIO_C_EXTRA_INCLUDE_DIRS}>)
 target_link_libraries (pioc
   PUBLIC ${PIO_C_EXTRA_LIBRARIES})
 target_compile_options (pioc

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -48,9 +48,9 @@ endif ()
 
 # Include flib source and binary directories (for Fortran modules)
 target_include_directories (piof
-  PUBLIC ${CMAKE_BINARY_DIR}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 # System and compiler CPP directives
 target_compile_definitions (piof
@@ -104,11 +104,21 @@ endif ()
 #  DEFINE THE INSTALL
 #==============================================================================
 
+set_target_properties (piof PROPERTIES EXPORT_NAME PIO_Fortran)
+
 # Library
-install (TARGETS piof DESTINATION lib)
+install (TARGETS piof
+  EXPORT PIOFortranTargets
+  DESTINATION lib
+  INCLUDES DESTINATION include)
 
 # Fortran Modules
 install (FILES ${PIO_Fortran_MODS} DESTINATION include)
+
+install(EXPORT PIOFortranTargets
+  FILE PIOFortranTargets.cmake
+  NAMESPACE PIO::
+  DESTINATION lib/cmake/PIO)
 
 #==============================================================================
 #  DEFINE THE DEPENDENCIES
@@ -239,7 +249,7 @@ endif ()
 
 #===== Add EXTRAs =====
 target_include_directories (piof
-  PUBLIC ${PIO_Fortran_EXTRA_INCLUDE_DIRS})
+  PUBLIC $<BUILD_INTERFACE:${PIO_Fortran_EXTRA_INCLUDE_DIRS}>)
 target_link_libraries (piof
   PUBLIC ${PIO_Fortran_EXTRA_LIBRARIES})
 target_compile_options (piof

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -27,8 +27,8 @@ set (GPTL_Fortran_MODS ${CMAKE_CURRENT_BINARY_DIR}/perf_mod.mod
 add_library (gptl ${GPTL_Fortran_SRCS} ${GPTL_C_SRCS})
 
 target_include_directories (gptl
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 target_compile_definitions (gptl
   PUBLIC INCLUDE_CMAKE_FCI)
@@ -54,14 +54,24 @@ endif ()
 #  DEFINE THE INSTALL
 #==============================================================================
 
+set_target_properties (gptl PROPERTIES EXPORT_NAME PIO_GPTL)
+
 # Library
-install (TARGETS gptl DESTINATION lib)
+install (TARGETS gptl
+  EXPORT PIOGPTLTargets
+  DESTINATION lib
+  INCLUDES DESTINATION include)
 
 # Header/Include File
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/gptl.h DESTINATION include)
 
 # Fortran Modules
 install (FILES ${GPTL_Fortran_MODS} DESTINATION include)
+
+install(EXPORT PIOGPTLTargets
+  FILE PIOGPTLTargets.cmake
+  NAMESPACE PIO::
+  DESTINATION lib/cmake/PIO)
 
 #==============================================================================
 #  DEFINE THE DEPENDENCIES


### PR DESCRIPTION
Minimum required changes to install a CMake package configuration file containing the PIO_C, PIO_Fortran and PIO_GPTL targets.

